### PR TITLE
feat: env refactors, better setup checks

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,17 +9,6 @@ permissions:
 
 jobs:
   ########################################
-  # TODO: what does this do?
-  ########################################
-  check_release:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Echo tag
-        run: |
-          echo "tag name: ${{ github.event.release.tag_name }}"
-          echo "release name: ${{ github.event.release.name }}"
-
-  ########################################
   # Builds the releases for all platforms
   ########################################
   build:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,6 +8,7 @@ on:
       - "src/**"
       - "tests/**"
       - "Cargo.lock"
+      - "Cargo.toml"
       - ".github/workflows/tests.yml"
   workflow_dispatch:
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -637,7 +637,7 @@ dependencies = [
 
 [[package]]
 name = "dkn-compute-launcher"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "clap",
  "colored",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "dkn-compute-launcher"
 edition = "2021"
-version = "0.1.6"
+version = "0.1.7"
 license = "Apache-2.0"
 readme = "README.md"
 description = "Dria Compute Node Launcher"

--- a/src/commands/editor.rs
+++ b/src/commands/editor.rs
@@ -26,7 +26,7 @@ pub fn edit_environment_file(env_path: &Path) -> Result<()> {
     let Some(new_env_content) =
         Editor::new(&format!("Edit environment file at {}:", env_path.display()))
             .with_predefined_text(&existing_env_content)
-            .with_help_message("ESC to go back") // TODO: !!!
+            .with_help_message("ESC to go back")
             .prompt_skippable()?
     else {
         return Ok(());

--- a/src/commands/info.rs
+++ b/src/commands/info.rs
@@ -4,25 +4,26 @@ use crate::utils::DriaEnv;
 pub fn show_info() {
     let dria_env = DriaEnv::new_from_env();
 
+    // wallet
     if let Ok((_, _, addr)) = dria_env.get_account() {
         eprintln!("Address: {}", addr);
+    } else {
+        eprintln!("Address: no wallet configured!");
     }
 
+    // log levels
     eprintln!(
         "Log Levels: {}",
-        dria_env.get("RUST_LOG").unwrap_or("<none>")
+        dria_env.get(DriaEnv::LOG_LEVEL_KEY).unwrap_or("none")
     );
 
-    eprintln!(
-        "Models: {}",
-        dria_env
-            .get_model_config()
-            .models
-            .iter()
-            .map(|(_, m)| m.to_string())
-            .collect::<Vec<_>>()
-            .join(", ")
-    );
+    // models
+    let model_names = dria_env.get_model_config().get_model_names();
+    if model_names.is_empty() {
+        eprintln!("Models: no models configured!");
+    } else {
+        eprintln!("Models:\n - {}", model_names.join("\n - "));
+    }
 
     eprintln!("Version: {}", env!("CARGO_PKG_VERSION"));
 }

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,5 +1,5 @@
 mod start;
-pub use start::run_compute;
+pub use start::run_compute_node;
 
 mod editor;
 pub use editor::edit_environment_file;

--- a/src/commands/points.rs
+++ b/src/commands/points.rs
@@ -32,11 +32,14 @@ where
 }
 
 /// Returns the $DRIA points for the users address.
+///
+/// - Will ask for user to enter their secret key if it is not set.
 pub async fn show_points() -> eyre::Result<()> {
-    let dria_env = DriaEnv::new_from_env();
+    let mut dria_env = DriaEnv::new_from_env();
+    dria_env.ask_for_key_if_required()?;
     let (_, _, address) = dria_env.get_account()?;
 
-    // the address can have 0x or not, we add it ourselves here
+    // the address can have 0x or not, we enforce it ourselves here
     let url = format!(
         "{}?address=0x{}",
         POINTS_API_BASE_URL,

--- a/src/commands/referrals.rs
+++ b/src/commands/referrals.rs
@@ -6,18 +6,17 @@ use crate::utils::{referrals::*, DriaEnv, Selectable};
 
 /// Referrals-related commands.
 ///
-/// If you are referred by a user, it is shown on the logs. Otherwise, a command is shown.
-/// If you have referred users, they are shown on the logs. Otherwise, a command is shown.
+/// - Will ask for user to enter their secret key if it is not set.
 pub async fn handle_referrals() -> eyre::Result<()> {
-    let client = ReferralsClient::default();
-
     // ensure system is healthy
+    let client = ReferralsClient::default();
     if !client.healthcheck().await {
         return Err(eyre!("Referrals API is offline."));
     }
 
     // get wallet secret from env
-    let dria_env = DriaEnv::new_from_env();
+    let mut dria_env = DriaEnv::new_from_env();
+    dria_env.ask_for_key_if_required()?;
     let (sk, _, addr) = dria_env.get_account()?;
 
     loop {

--- a/src/commands/setup.rs
+++ b/src/commands/setup.rs
@@ -6,14 +6,11 @@ use crate::{
     utils::DriaEnv,
 };
 
-/// Asks for the following information for the env:
+/// Asks for the following information for the user environment:
 ///
 /// 1. Secret key (Wallet)
 /// 2. Models
-/// 3. API Keys for respective model providers
-/// 4. Optional API Keys for Jina and Serper
-///
-/// This also runs on first launch when an env file is not found.
+/// 3. Optional API Keys for Jina and Serper
 ///
 /// ### Arguments
 /// - `env_path`: path to the environment file
@@ -30,15 +27,6 @@ pub fn setup_environment(env_path: &Path) -> Result<()> {
     // ask for models
     log::info!("Choose models that you would like to run.");
     settings::edit_models(&mut dria_env)?;
-
-    // ask for API keys w.r.t models
-    let configured_providers = dria_env.get_model_config().get_providers();
-    let required_api_keys = DriaApiKeyKind::from_providers(&configured_providers);
-    for api_key in required_api_keys {
-        log::info!("Provide {} because you are using its model", api_key);
-        let new_value = api_key.prompt_api(&dria_env)?;
-        dria_env.set(api_key.name(), new_value);
-    }
 
     // ask for Jina and Serper api keys (optional)
     for optional_api_key in DriaApiKeyKind::optional_apis() {

--- a/src/commands/setup.rs
+++ b/src/commands/setup.rs
@@ -6,7 +6,7 @@ use crate::{
     utils::DriaEnv,
 };
 
-/// Creates & sets up a new environment. It specifically asks for the following:
+/// Asks for the following information for the env:
 ///
 /// 1. Secret key (Wallet)
 /// 2. Models

--- a/src/commands/specific.rs
+++ b/src/commands/specific.rs
@@ -25,6 +25,21 @@ pub async fn download_specific_release(exe_dir: &Path, tag: Option<&String>) -> 
 
     let releases = get_releases(DriaRepository::ComputeNode).await?;
 
+    // filter out non-well formed releases, all release should be like `vX.Y.Z`,
+    // this is done so that launcher doesnt clutter the prompt with non-release versions
+    let releases = releases
+        .into_iter()
+        .filter(|release| {
+            // check if the version is well form
+            let parts = release.version().split('.').collect::<Vec<_>>();
+
+            parts.len() == 3
+                && parts[0].parse::<u32>().is_ok()
+                && parts[1].parse::<u32>().is_ok()
+                && parts[2].parse::<u32>().is_ok()
+        })
+        .collect::<Vec<_>>();
+
     let chosen_release = match tag {
         // choose the tag directly
         Some(tag) => releases

--- a/src/commands/start.rs
+++ b/src/commands/start.rs
@@ -1,12 +1,20 @@
 use eyre::{Context, Result};
+use ollama_rs::Ollama;
 use std::path::Path;
 use tokio::process::Command;
 use tokio_util::sync::CancellationToken;
 
 use crate::{
-    utils::{check_ollama, configure_fdlimit, spawn_ollama, ComputeInstance},
+    settings::{self, DriaApiKeyKind},
+    utils::{
+        check_ollama, configure_fdlimit, pull_model_with_progress, spawn_ollama, ComputeInstance,
+    },
     DriaEnv, DKN_LAUNCHER_VERSION,
 };
+
+/// An env key that compute node checks to get the path to the environment file.
+/// This is set by the launcher when it spawns the compute node.
+const DKN_COMPUTE_ENV_KEY: &str = "DKN_COMPUTE_ENV";
 
 /// Starts the latest compute node version at the given path.
 ///
@@ -27,9 +35,18 @@ use crate::{
 /// - If the compute node process could not be spawned
 /// - If the Ollama process is required but could not be spawned
 /// - If the file-descriptor limits could not be set
-pub async fn run_compute(exe_path: &Path, check_updates: bool) -> Result<ComputeInstance> {
+pub async fn run_compute_node(
+    exe_path: &Path,
+    env_path: &Path,
+    check_updates: bool,
+) -> Result<ComputeInstance> {
     // get the executables directory back from the path
     let exe_dir = exe_path.parent().expect("must be a file");
+
+    let mut dria_env = DriaEnv::new_from_env();
+    dria_env.ask_for_key_if_required()?;
+    dria_env.save_to_file(&env_path)?;
+    let workflow_config = dria_env.get_model_config();
 
     // check the update if requested, similar to calling `update` command
     if check_updates {
@@ -37,8 +54,10 @@ pub async fn run_compute(exe_path: &Path, check_updates: bool) -> Result<Compute
         super::update(exe_dir).await;
     }
 
-    let dria_env = DriaEnv::new_from_env();
-    let workflow_config = dria_env.get_model_config();
+    println!(
+        "{:?}",
+        workflow_config.get_models_for_provider(dkn_workflows::ModelProvider::Ollama)
+    );
 
     // check if Ollama is running & run it if not
     let ollama_process = if !workflow_config
@@ -54,6 +73,9 @@ pub async fn run_compute(exe_path: &Path, check_updates: bool) -> Result<Compute
         None // no need for Ollama
     };
 
+    // at this point, we have Ollama running if required, now we can check for models
+    ensure_models_are_ready(&mut dria_env).await?;
+
     // set file-descriptor limits in Unix, not needed in Windows
     configure_fdlimit();
 
@@ -64,6 +86,7 @@ pub async fn run_compute(exe_path: &Path, check_updates: bool) -> Result<Compute
 
     // spawn compute node
     let compute_process = Command::new(exe_path)
+        .env(DKN_COMPUTE_ENV_KEY, env_path)
         .spawn()
         .wrap_err("failed to spawn compute node")?;
 
@@ -75,4 +98,64 @@ pub async fn run_compute(exe_path: &Path, check_updates: bool) -> Result<Compute
         check_updates,
         cancellation,
     })
+}
+
+/// Asks for models if they are not already set in the environment.
+///
+/// - Asks for API keys on the respective model providers.
+/// - Pulls local models if required.
+async fn ensure_models_are_ready(dria_env: &mut DriaEnv) -> eyre::Result<()> {
+    while dria_env.get_model_config().models.is_empty() {
+        log::warn!("No models configured. Please choose at least one model to run.");
+        settings::edit_models(dria_env)?;
+    }
+
+    // FIXME: something weird about env here, todo test with Ollama
+
+    let model_config = dria_env.get_model_config();
+
+    // check API keys for the requied models
+    let required_api_keys = DriaApiKeyKind::from_providers(&model_config.get_providers());
+    for api_key in required_api_keys {
+        log::info!("Provide {} because you are using its model", api_key);
+        let new_value = api_key.prompt_api(dria_env)?;
+        dria_env.set(api_key.name(), new_value);
+    }
+
+    // pull local models if used
+    let ollama_models = model_config.get_models_for_provider(dkn_workflows::ModelProvider::Ollama);
+    if !ollama_models.is_empty() {
+        // create ollama instance
+        let (host, port) = dria_env.get_ollama_config();
+        let ollama = Ollama::new(host, port);
+
+        // get local models
+        let local_model_names = ollama
+            .list_local_models()
+            .await?
+            .into_iter()
+            .map(|m| m.name)
+            .collect::<Vec<_>>();
+
+        // find models that are not available locally
+        let models_to_be_pulled = ollama_models
+            .iter()
+            .filter(|model| !local_model_names.contains(&model.to_string()))
+            .collect::<Vec<_>>();
+
+        // pull all selected & non-pulled models
+        if !models_to_be_pulled.is_empty() {
+            log::info!("The following models are selected but not found locally:");
+            for model in &models_to_be_pulled {
+                log::info!("  - {}", model);
+            }
+
+            log::info!("Pulling models from Ollama...");
+            for model in models_to_be_pulled {
+                pull_model_with_progress(&ollama, model.to_string()).await?;
+            }
+        }
+    }
+
+    Ok(())
 }

--- a/src/commands/start.rs
+++ b/src/commands/start.rs
@@ -43,38 +43,93 @@ pub async fn run_compute_node(
     // get the executables directory back from the path
     let exe_dir = exe_path.parent().expect("must be a file");
 
-    let mut dria_env = DriaEnv::new_from_env();
-    dria_env.ask_for_key_if_required()?;
-    dria_env.save_to_file(&env_path)?;
-    let workflow_config = dria_env.get_model_config();
-
     // check the update if requested, similar to calling `update` command
     if check_updates {
-        log::info!("Checking for updates.");
         super::update(exe_dir).await;
     }
 
-    println!(
-        "{:?}",
-        workflow_config.get_models_for_provider(dkn_workflows::ModelProvider::Ollama)
-    );
+    // read existing env
+    let mut dria_env = DriaEnv::new_from_env();
 
-    // check if Ollama is running & run it if not
-    let ollama_process = if !workflow_config
-        .get_models_for_provider(dkn_workflows::ModelProvider::Ollama)
-        .is_empty()
-    {
-        if check_ollama(&dria_env).await {
+    // ensure there are models
+    while dria_env.get_model_config().models.is_empty() {
+        log::warn!("No models configured. Please choose at least one model to run.");
+        settings::edit_models(&mut dria_env)?;
+    }
+    let workflow_config = dria_env.get_model_config();
+
+    // ensure key is set
+    dria_env.ask_for_key_if_required()?;
+
+    // check API keys for the requied models
+    let required_api_keys = DriaApiKeyKind::from_providers(&workflow_config.get_providers());
+    for api_key in required_api_keys {
+        log::info!("Provide {} because you are using its model", api_key);
+        let new_value = api_key.prompt_api(&dria_env)?;
+        dria_env.set(api_key.name(), new_value);
+    }
+
+    // check if Ollama is required & running, and run it if not
+    let ollama_models =
+        workflow_config.get_models_for_provider(dkn_workflows::ModelProvider::Ollama);
+    let ollama_process = if !ollama_models.is_empty() {
+        // spawn Ollama if needed
+        let ollama_process_opt = if check_ollama(&dria_env).await {
             None
         } else {
             Some(spawn_ollama(&dria_env).await?)
+        };
+
+        // create ollama instance
+        let (host, port) = dria_env.get_ollama_config();
+        let ollama = Ollama::new(host, port);
+
+        // get local models
+        let local_model_names = ollama
+            .list_local_models()
+            .await?
+            .into_iter()
+            .map(|m| m.name)
+            .collect::<Vec<_>>();
+
+        // find models that are not available locally
+        let models_to_be_pulled = ollama_models
+            .iter()
+            .filter(|model| !local_model_names.contains(&model.to_string()))
+            .collect::<Vec<_>>();
+
+        // pull all selected & non-pulled models
+        if !models_to_be_pulled.is_empty() {
+            log::info!(
+                "The following models are selected but not found locally:\n{}",
+                models_to_be_pulled
+                    .iter()
+                    .map(|m| format!("  - {}", m))
+                    .collect::<Vec<_>>()
+                    .join("\n")
+            );
+
+            log::info!("Pulling models from Ollama...");
+            for model in models_to_be_pulled {
+                pull_model_with_progress(&ollama, model.to_string()).await?;
+            }
         }
+
+        ollama_process_opt
     } else {
         None // no need for Ollama
     };
 
-    // at this point, we have Ollama running if required, now we can check for models
-    ensure_models_are_ready(&mut dria_env).await?;
+    // save to file if there were any changes
+    if dria_env.is_changed() {
+        dria_env.save_to_file(&env_path)?;
+
+        // override the env file with the new values, needed for the compute node
+        // as even if it reads from env again, it will not override existing values
+        if let Err(err) = dotenvy::from_path_override(&env_path) {
+            log::warn!("Failed to override with env: {}", err);
+        }
+    }
 
     // set file-descriptor limits in Unix, not needed in Windows
     configure_fdlimit();
@@ -98,64 +153,4 @@ pub async fn run_compute_node(
         check_updates,
         cancellation,
     })
-}
-
-/// Asks for models if they are not already set in the environment.
-///
-/// - Asks for API keys on the respective model providers.
-/// - Pulls local models if required.
-async fn ensure_models_are_ready(dria_env: &mut DriaEnv) -> eyre::Result<()> {
-    while dria_env.get_model_config().models.is_empty() {
-        log::warn!("No models configured. Please choose at least one model to run.");
-        settings::edit_models(dria_env)?;
-    }
-
-    // FIXME: something weird about env here, todo test with Ollama
-
-    let model_config = dria_env.get_model_config();
-
-    // check API keys for the requied models
-    let required_api_keys = DriaApiKeyKind::from_providers(&model_config.get_providers());
-    for api_key in required_api_keys {
-        log::info!("Provide {} because you are using its model", api_key);
-        let new_value = api_key.prompt_api(dria_env)?;
-        dria_env.set(api_key.name(), new_value);
-    }
-
-    // pull local models if used
-    let ollama_models = model_config.get_models_for_provider(dkn_workflows::ModelProvider::Ollama);
-    if !ollama_models.is_empty() {
-        // create ollama instance
-        let (host, port) = dria_env.get_ollama_config();
-        let ollama = Ollama::new(host, port);
-
-        // get local models
-        let local_model_names = ollama
-            .list_local_models()
-            .await?
-            .into_iter()
-            .map(|m| m.name)
-            .collect::<Vec<_>>();
-
-        // find models that are not available locally
-        let models_to_be_pulled = ollama_models
-            .iter()
-            .filter(|model| !local_model_names.contains(&model.to_string()))
-            .collect::<Vec<_>>();
-
-        // pull all selected & non-pulled models
-        if !models_to_be_pulled.is_empty() {
-            log::info!("The following models are selected but not found locally:");
-            for model in &models_to_be_pulled {
-                log::info!("  - {}", model);
-            }
-
-            log::info!("Pulling models from Ollama...");
-            for model in models_to_be_pulled {
-                pull_model_with_progress(&ollama, model.to_string()).await?;
-            }
-        }
-    }
-
-    Ok(())
 }

--- a/src/commands/start.rs
+++ b/src/commands/start.rs
@@ -122,11 +122,11 @@ pub async fn run_compute_node(
 
     // save to file if there were any changes
     if dria_env.is_changed() {
-        dria_env.save_to_file(&env_path)?;
+        dria_env.save_to_file(env_path)?;
 
         // override the env file with the new values, needed for the compute node
         // as even if it reads from env again, it will not override existing values
-        if let Err(err) = dotenvy::from_path_override(&env_path) {
+        if let Err(err) = dotenvy::from_path_override(env_path) {
             log::warn!("Failed to override with env: {}", err);
         }
     }

--- a/src/commands/uninstall.rs
+++ b/src/commands/uninstall.rs
@@ -69,8 +69,10 @@ pub async fn uninstall_launcher(env_dir: &Path, env_path: &Path) -> eyre::Result
     self_update::self_replace::self_delete()?;
 
     // remove .env file within the directory
-    log::info!("Removing environment file: {}", env_path.display());
-    std::fs::remove_file(env_path)?;
+    if env_path.exists() {
+        log::info!("Removing environment file: {}", env_path.display());
+        std::fs::remove_file(env_path)?;
+    }
 
     Ok(())
 }

--- a/src/commands/uninstall.rs
+++ b/src/commands/uninstall.rs
@@ -21,7 +21,6 @@ use crate::utils::DKN_VERSION_TRACKER_FILE;
 /// ### Notes
 /// - The user is asked for confirmation before uninstalling.
 pub async fn uninstall_launcher(env_dir: &Path, env_path: &Path) -> eyre::Result<()> {
-    // get the launcher path
     let launcher_path = std::env::current_exe()?;
 
     // ask for confirmation

--- a/src/commands/update.rs
+++ b/src/commands/update.rs
@@ -15,7 +15,7 @@ use crate::utils::{
 /// - `exe_dir`: directory where the binary is located
 #[inline]
 pub async fn update(exe_dir: &Path) {
-    log::debug!("Checking compute node version.");
+    log::info!("Checking compute node updates.");
     if let Err(e) = update_compute(exe_dir).await {
         log::error!("Error updating compute node: {}", e);
     }
@@ -23,7 +23,7 @@ pub async fn update(exe_dir: &Path) {
     // update the launcher only in release mode, otherwise this will try to update
     // when you are running with `cargo run` etc.
     if !cfg!(debug_assertions) {
-        log::debug!("Checking launcher version.");
+        log::info!("Checking launcher updates.");
         if let Err(e) = update_launcher(exe_dir).await {
             log::error!("Error updating launcher: {}", e);
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,18 +16,27 @@ struct Cli {
     #[command(subcommand)]
     command: Commands,
 
-    /// Path to the .env file.
+    /// Path to the .env file
     #[arg(short, long, default_value = commands::default_env())]
-    pub env: PathBuf,
+    env: PathBuf,
 
-    /// Profile name to run multiple compute nodes with different settings.
-    /// TODO: !!!
-    #[arg(short, long)]
-    pub profile: Option<String>,
+    /// Profile name for the environment file
+    #[arg(short, long, value_parser = parse_profile)]
+    profile: Option<String>,
+}
 
-    /// Enable debug-level logs
-    #[arg(short, long)]
-    pub debug: bool,
+/// Ensures that the profile name contains only alphanumeric characters, '-', or '_'.
+fn parse_profile(profile: &str) -> eyre::Result<String> {
+    if !profile
+        .chars()
+        .all(|c| c.is_alphanumeric() || c == '-' || c == '_')
+    {
+        return Err(eyre::eyre!(
+            "Profile name must contain only alphanumeric characters, '-', or '_'"
+        ));
+    }
+
+    Ok(profile.to_string())
 }
 
 #[tokio::main]
@@ -35,30 +44,42 @@ async fn main() -> eyre::Result<()> {
     // default commands such as version and help exit at this point
     let cli = Cli::parse();
 
+    // env is given by the path, and must be a file
+    let mut env_path = cli.env;
+    if !env_path.is_file() {
+        return Err(eyre::eyre!(
+            "env path must be a file: {}",
+            env_path.display()
+        ));
+    }
+
+    // `.<profile>` is appended to the path if given
+    if let Some(profile) = cli.profile {
+        // we expect this to work because the path is checked to be a file
+        let existing_file_name = env_path.file_name().unwrap().to_str().unwrap();
+        env_path.set_file_name(format!("{existing_file_name}.{profile}"));
+    }
+
     // read env w.r.t cli argument
-    let dotenv_result = dotenvy::from_path(&cli.env);
+    let dotenv_result = dotenvy::from_path(&env_path);
 
     // init env logger
-    let log_level = match cli.debug {
-        true => log::LevelFilter::Debug,
-        false => log::LevelFilter::Info,
-    };
     env_logger::builder()
         .format_timestamp(Some(env_logger::TimestampPrecision::Seconds))
         .filter(None, log::LevelFilter::Off)
-        .filter_module("dkn_compute_launcher", log_level)
+        .filter_module("dkn_compute_launcher", log::LevelFilter::Info)
         .parse_default_env()
         .init();
 
     // log about env usage after env logger init is executed
     match dotenv_result {
-        Ok(_) => log::info!("Loaded env file at: {}", cli.env.display()),
+        Ok(_) => log::info!("Loaded env file at: {}", env_path.display()),
         Err(_) => {
             log::warn!(
                 "No env file found at {}, creating a new one",
-                cli.env.display()
+                env_path.display()
             );
-            DriaEnv::new_default_file(&cli.env)?;
+            DriaEnv::new_default_file(&env_path)?;
         }
     }
 
@@ -66,19 +87,18 @@ async fn main() -> eyre::Result<()> {
     // when a given path is relative, the parent may be empty; this is handled by checking
     // if the underlying `OsStr` is empty or not, in which case the fallback is given by
     // the `std::env::current_dir` function.
-    let exe_dir = cli
-        .env
+    let exe_dir = env_path
         .parent()
         .map(|dir| dir.to_owned())
         .filter(|dir| !dir.as_os_str().is_empty())
         .unwrap_or_else(|| std::env::current_dir().expect("could not get current directory"));
 
     match &cli.command {
-        Commands::Settings => commands::change_settings(&cli.env).await?,
-        Commands::Setup => commands::setup_environment(&cli.env)?,
+        Commands::Settings => commands::change_settings(&env_path).await?,
+        Commands::Setup => commands::setup_environment(&env_path)?,
         Commands::Points => commands::show_points().await?,
-        Commands::EnvEditor => commands::edit_environment_file(&cli.env)?,
-        Commands::Uninstall => commands::uninstall_launcher(&exe_dir, &cli.env).await?,
+        Commands::EnvEditor => commands::edit_environment_file(&env_path)?,
+        Commands::Uninstall => commands::uninstall_launcher(&exe_dir, &env_path).await?,
         Commands::Info => commands::show_info(),
         Commands::Update => commands::update(&exe_dir).await,
         Commands::Specific { run, tag } => {
@@ -88,7 +108,7 @@ async fn main() -> eyre::Result<()> {
 
             // if `run` is true, the binary is executed immediately
             if *run {
-                commands::run_compute_node(&exe_path, &cli.env, false)
+                commands::run_compute_node(&exe_path, &env_path, false)
                     .await?
                     .monitor_process()
                     .await;
@@ -101,7 +121,7 @@ async fn main() -> eyre::Result<()> {
             // e.g. `./my/dir/dkn-compute-node_latest`
             let exe_path = exe_dir.join(DKN_LATEST_COMPUTE_FILE);
 
-            commands::run_compute_node(&exe_path, &cli.env, true)
+            commands::run_compute_node(&exe_path, &env_path, true)
                 .await?
                 .monitor_process()
                 .await;

--- a/src/settings/apikey.rs
+++ b/src/settings/apikey.rs
@@ -58,6 +58,17 @@ impl DriaApiKeyKind {
         }
     }
 
+    /// Returns a help message for the API key, e.g. where to get it from.
+    pub fn help_message(&self) -> &'static str {
+        match self {
+            Self::OpenAI => "Get yours at https://platform.openai.com/api-keys",
+            Self::Gemini => "Get yours at https://aistudio.google.com/app/apikey",
+            Self::OpenRouter => "Get yours at https://openrouter.ai/keys",
+            Self::Serper => "Get yours at https://serper.dev/",
+            Self::Jina => "API key for Jina API",
+        }
+    }
+
     /// Given a list of providers (can contain duplicates) returns the unique set of API key kinds.
     pub fn from_providers(providers: &[ModelProvider]) -> Vec<DriaApiKeyKind> {
         let set: HashSet<DriaApiKeyKind> =
@@ -65,13 +76,13 @@ impl DriaApiKeyKind {
                 ModelProvider::OpenAI => Some(DriaApiKeyKind::OpenAI),
                 ModelProvider::Gemini => Some(DriaApiKeyKind::Gemini),
                 ModelProvider::OpenRouter => Some(DriaApiKeyKind::OpenRouter),
-                ModelProvider::Ollama => None,
-                ModelProvider::VLLM => None,
+                _ => None,
             }));
 
         set.into_iter().collect()
     }
 
+    #[inline]
     pub fn optional_apis() -> Vec<DriaApiKeyKind> {
         vec![DriaApiKeyKind::Jina, DriaApiKeyKind::Serper]
     }
@@ -81,7 +92,7 @@ impl DriaApiKeyKind {
     pub fn prompt_api(&self, dria_env: &DriaEnv) -> InquireResult<String> {
         inquire::Text::new(&format!("Enter your {}:", self.name()))
             .with_default(dria_env.get(self.name()).unwrap_or_default())
-            .with_help_message("ENTER without typing anything to keep using the existing value")
+            .with_help_message(self.help_message())
             .prompt()
     }
 }

--- a/src/settings/loglevel.rs
+++ b/src/settings/loglevel.rs
@@ -80,10 +80,9 @@ pub fn edit_log_level(dria_env: &mut DriaEnv) -> eyre::Result<()> {
     Ok(())
 }
 
-/// An enum to represent modules that we care about logging as a w
+/// An enum to represent modules that we care about logging
 #[derive(Debug, Clone, enum_iterator::Sequence)]
 enum LogModules {
-    DknComputeLauncher,
     DknComputeNode,
     DknP2P,
     DknWorkflows,
@@ -99,7 +98,6 @@ impl LogModules {
 
     pub fn as_rust_log(&self) -> &'static str {
         match self {
-            Self::DknComputeLauncher => "dkn_compute_launcher",
             Self::DknComputeNode => "dkn_compute",
             Self::DknP2P => "dkn_p2p",
             Self::DknWorkflows => "dkn_workflows",
@@ -113,7 +111,6 @@ impl LogModules {
 impl std::fmt::Display for LogModules {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::DknComputeLauncher => write!(f, "Dria Compute Launcher"),
             Self::DknComputeNode => write!(f, "Dria Compute Node: Core"),
             Self::DknP2P => write!(f, "Dria Compute Node: P2P"),
             Self::DknWorkflows => write!(f, "Dria Compute Node: Workflows"),

--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -1,7 +1,7 @@
 use colored::Colorize;
 
 mod models;
-pub use models::edit_models;
+pub use models::edit_models; // used by `setup` command
 pub use models::show_model_settings_menu;
 
 mod apikey;

--- a/src/settings/models/edit.rs
+++ b/src/settings/models/edit.rs
@@ -1,7 +1,7 @@
 use dkn_workflows::{Model, ModelProvider};
 use inquire::{MultiSelect, Select};
 
-use crate::{settings::models::MODELS_KEY, utils::Selectable, DriaEnv};
+use crate::{utils::Selectable, DriaEnv};
 
 /// Edit the chosen models.
 pub fn edit_models(dria_env: &mut DriaEnv) -> eyre::Result<()> {
@@ -80,7 +80,7 @@ pub fn edit_models(dria_env: &mut DriaEnv) -> eyre::Result<()> {
         new_models.sort();
 
         log::info!("Chosen models:\n - {}", new_models.join("\n - "));
-        dria_env.set(MODELS_KEY, new_models.join(","));
+        dria_env.set(DriaEnv::DKN_MODELS_KEY, new_models.join(","));
     } else {
         log::info!("No changes made.");
     }

--- a/src/settings/models/measure.rs
+++ b/src/settings/models/measure.rs
@@ -23,7 +23,7 @@ const MINIMUM_DURATION_MS: u64 = 80_000;
 /// - If Ollama is not available / something is wrong about the chosen model.
 pub async fn measure_tps(dria_env: &DriaEnv) -> eyre::Result<()> {
     // ensure Ollama is available
-    if !check_ollama(&dria_env).await {
+    if !check_ollama(dria_env).await {
         return Err(eyre!("Ollama is not available, please run Ollama server."));
     }
 
@@ -32,17 +32,7 @@ pub async fn measure_tps(dria_env: &DriaEnv) -> eyre::Result<()> {
 
     // get users ollama models
     let models_config = dria_env.get_model_config();
-    let my_ollama_models = models_config
-        .models
-        .iter()
-        .filter_map(|(p, m)| {
-            if *p == ModelProvider::Ollama {
-                Some(m.clone())
-            } else {
-                None
-            }
-        })
-        .collect::<Vec<_>>();
+    let my_ollama_models = models_config.get_models_for_provider(ModelProvider::Ollama);
 
     // find indexes of existing chosen ollama models on the user
     let default_selected_idxs = all_ollama_models
@@ -78,7 +68,7 @@ pub async fn measure_tps(dria_env: &DriaEnv) -> eyre::Result<()> {
 
     // create ollama instance
     let (host, port) = dria_env.get_ollama_config();
-    let ollama = Ollama::new(host, port.parse().unwrap_or(11434));
+    let ollama = Ollama::new(host, port);
 
     // get local models
     let local_model_names = ollama

--- a/src/settings/models/measure.rs
+++ b/src/settings/models/measure.rs
@@ -90,9 +90,7 @@ pub async fn measure_tps(dria_env: &DriaEnv) -> eyre::Result<()> {
     {
         let model_name = model.to_string();
 
-        if local_model_names.contains(&model_name) {
-            log::debug!("Model {} exists locally.", model_name);
-        } else {
+        if !local_model_names.contains(&model_name) {
             log::info!(
                 "Model {} does not exist locally, pulling it from Ollama.",
                 model_name
@@ -103,7 +101,6 @@ pub async fn measure_tps(dria_env: &DriaEnv) -> eyre::Result<()> {
         }
 
         // do an embedding request to warm stuff up
-        log::debug!("Warming up model {} with an embedding generation.", model);
         let request = GenerateEmbeddingsRequest::new(
             model.to_string(),
             EmbeddingsInput::Single("and the bird you cannot change".into()),
@@ -123,7 +120,6 @@ pub async fn measure_tps(dria_env: &DriaEnv) -> eyre::Result<()> {
             .await
         {
             Ok(response) => {
-                log::debug!("Got response for model {}", model);
                 table.add_row(response.into());
             }
             Err(e) => {

--- a/src/settings/models/mod.rs
+++ b/src/settings/models/mod.rs
@@ -15,8 +15,6 @@ use measure::measure_tps;
 mod remove;
 use remove::remove_local_models;
 
-const MODELS_KEY: &str = "DKN_MODELS";
-
 #[derive(Debug, Clone, enum_iterator::Sequence)]
 enum ModelSettings {
     Edit,

--- a/src/settings/models/remove.rs
+++ b/src/settings/models/remove.rs
@@ -7,13 +7,13 @@ use crate::{utils::check_ollama, DriaEnv};
 /// Remove local models (same as `ollama rm`).
 pub async fn remove_local_models(dria_env: &mut DriaEnv) -> eyre::Result<()> {
     // ensure Ollama is available
-    if !check_ollama(&dria_env).await {
+    if !check_ollama(dria_env).await {
         return Err(eyre!("Ollama is not available, please run Ollama server."));
     }
 
     // create ollama instance
     let (host, port) = dria_env.get_ollama_config();
-    let ollama = Ollama::new(host, port.parse().unwrap_or(11434));
+    let ollama = Ollama::new(host, port);
 
     // get local models
     let local_models = ollama

--- a/src/settings/ollama.rs
+++ b/src/settings/ollama.rs
@@ -3,18 +3,13 @@ use reqwest::Url;
 
 use crate::DriaEnv;
 
-const OLLAMA_HOST_KEY: &str = "OLLAMA_HOST";
-const OLLAMA_PORT_KEY: &str = "OLLAMA_PORT";
-const DEFAULT_OLLAMA_HOST: &str = "http://localhost";
-const DEFAULT_OLLAMA_PORT: &str = "11434";
-
 /// Prompts the user to edit the Ollama server settings (host & port).
 pub fn edit_ollama(dria_env: &mut DriaEnv) -> eyre::Result<()> {
+    let (existing_host, existing_port) = dria_env.get_ollama_config();
+    let existing_host = existing_host.to_string();
+    let existing_port = existing_port.to_string();
+
     // change host
-    let existing_host = dria_env
-        .get(OLLAMA_HOST_KEY)
-        .unwrap_or(DEFAULT_OLLAMA_HOST)
-        .to_string();
     let new_host = Text::new("Enter host:")
         .with_default(&existing_host)
         .with_validator(|host_str: &str| match Url::parse(host_str) {
@@ -24,15 +19,13 @@ pub fn edit_ollama(dria_env: &mut DriaEnv) -> eyre::Result<()> {
             )),
         })
         .prompt()?;
-
     if new_host != existing_host {
-        dria_env.set(OLLAMA_HOST_KEY, new_host);
+        dria_env.set(DriaEnv::OLLAMA_HOST_KEY, new_host);
     }
 
     // change port
-    let existing_port = dria_env.get(OLLAMA_PORT_KEY).unwrap_or(DEFAULT_OLLAMA_PORT);
     let new_port = Text::new("Enter port:")
-        .with_default(existing_port)
+        .with_default(&existing_port)
         .with_validator(|port_str: &str| match port_str.parse::<u16>() {
             Ok(_) => Ok(Validation::Valid),
             Err(_) => Ok(Validation::Invalid(
@@ -41,7 +34,7 @@ pub fn edit_ollama(dria_env: &mut DriaEnv) -> eyre::Result<()> {
         })
         .prompt()?;
     if new_port != existing_host {
-        dria_env.set(OLLAMA_PORT_KEY, new_port);
+        dria_env.set(DriaEnv::OLLAMA_PORT_KEY, new_port);
     }
 
     Ok(())

--- a/src/settings/port.rs
+++ b/src/settings/port.rs
@@ -2,12 +2,13 @@ use inquire::{validator::Validation, Text};
 
 use crate::DriaEnv;
 
-const LISTEN_ADDR_KEY: &str = "DKN_P2P_LISTEN_ADDR";
 const DEFAULT_LISTEN_ADDR: &str = "/ip4/0.0.0.0/tcp/4001";
 
 pub fn edit_port(dria_env: &mut DriaEnv) -> eyre::Result<()> {
     // get existing address
-    let addr = &dria_env.get(LISTEN_ADDR_KEY).unwrap_or(DEFAULT_LISTEN_ADDR);
+    let addr = &dria_env
+        .get(DriaEnv::DKN_P2P_LISTEN_ADDR_KEY)
+        .unwrap_or(DEFAULT_LISTEN_ADDR);
 
     // ensure the address starts with `/ip4/0.0.0.0/tcp/` and ends with a number
     let mut parts = addr.split('/').collect::<Vec<_>>();
@@ -38,7 +39,7 @@ pub fn edit_port(dria_env: &mut DriaEnv) -> eyre::Result<()> {
         parts[4] = &new_port;
         let new_listen_addr = parts.join("/");
         log::info!("New listen address: {:?}", new_listen_addr);
-        dria_env.set(LISTEN_ADDR_KEY, new_listen_addr);
+        dria_env.set(DriaEnv::DKN_P2P_LISTEN_ADDR_KEY, new_listen_addr);
     }
 
     Ok(())

--- a/src/settings/wallet.rs
+++ b/src/settings/wallet.rs
@@ -2,10 +2,8 @@ use inquire::{validator::Validation, Password};
 
 use crate::DriaEnv;
 
-const WALLET_KEY: &str = "DKN_WALLET_SECRET_KEY";
-
 pub fn edit_wallet(dria_env: &mut DriaEnv, skippable: bool) -> eyre::Result<()> {
-    let existing_secret_opt = dria_env.get(WALLET_KEY);
+    let existing_secret_opt = dria_env.get(DriaEnv::DKN_WALLET_KEY);
 
     // masks a string "abcdefgh" to something like "ab****gh"
     // also ignores the 0x at the start
@@ -68,7 +66,7 @@ pub fn edit_wallet(dria_env: &mut DriaEnv, skippable: bool) -> eyre::Result<()> 
         .prompt()?;
 
     if !new_secret.is_empty() {
-        dria_env.set(WALLET_KEY, new_secret);
+        dria_env.set(DriaEnv::DKN_WALLET_KEY, new_secret);
     }
 
     Ok(())

--- a/src/utils/env.rs
+++ b/src/utils/env.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, io, path::Path};
+use std::{collections::HashMap, fs, io, path::Path};
 
 use dkn_workflows::DriaWorkflowsConfig;
 use eyre::OptionExt;
@@ -134,10 +134,10 @@ impl DriaEnv {
     pub fn save_to_file(&self, env_path: &Path) -> io::Result<()> {
         log::info!("Saving changes to {}", env_path.display());
 
-        let content = std::fs::read_to_string(env_path)?;
+        let content = fs::read_to_string(env_path)?;
         let new_content = self.save_to_content(&content);
 
-        std::fs::write(env_path, new_content)?;
+        fs::write(env_path, new_content)?;
         log::info!("Changes saved successfully.");
         Ok(())
     }
@@ -149,11 +149,11 @@ impl DriaEnv {
         // create directories if they dont exist
         if !env_path.exists() {
             if let Some(dir) = env_path.parent() {
-                std::fs::create_dir_all(dir)?;
+                fs::create_dir_all(dir)?;
             }
         }
 
-        std::fs::write(env_path, BASE_ENV_FILE_CONTENT)
+        fs::write(env_path, BASE_ENV_FILE_CONTENT)
     }
 
     /// Asks for a secret key for the wallet if it does not exist in the environment.

--- a/src/utils/fdlimit.rs
+++ b/src/utils/fdlimit.rs
@@ -6,12 +6,11 @@
 /// See more info about this [here](https://www.gnu.org/software/libc/manual/html_node/Limits-on-Resources.html).
 ///
 /// - Note that if `soft` limit is greater than `hard` limit it will require admin privileges to set the limits,
-///  so we only set the limits if the `soft` limit is less than the `hard` limit.
+///   so we only set the limits if the `soft` limit is less than the `hard` limit.
 ///
 /// - Has no effect on Windows.
 #[inline]
 pub fn configure_fdlimit() {
-    // set file-descriptor limits in Unix, not needed in Windows
     #[cfg(unix)]
     {
         // default hard limits, in case `getrlimit` fails
@@ -36,23 +35,12 @@ pub fn configure_fdlimit() {
         // only do this if soft-limit is below the target
         if soft < target_soft {
             if let Err(e) = rlimit::Resource::NOFILE.set(target_soft, hard) {
-                log::error!(
-                "Failed to set file-descriptor limits: {}, you may need to run as administrator!",
-                e
-            );
+                log::error!("Failed to set file-descriptor limits: {}, you may need to run as administrator!", e);
             } else {
-                log::warn!(
-                    "Using new resource limits (soft / hard): {} / {}",
-                    target_soft,
-                    hard
-                );
+                log::warn!("Using new resource limits (soft / hard): {target_soft} / {hard}");
             }
         } else {
-            log::info!(
-                "Using existing resource limits (soft / hard): {} / {}",
-                soft,
-                hard
-            );
+            log::info!("Using existing resource limits (soft / hard): {soft} / {hard}");
         }
     }
 }

--- a/src/utils/ollama.rs
+++ b/src/utils/ollama.rs
@@ -35,8 +35,8 @@ pub async fn spawn_ollama(dria_env: &DriaEnv) -> Result<Child> {
     log::debug!("Using Ollama executable at {:?}", exe_path);
 
     // ollama requires the OLLAMA_HOST environment variable to be set before launching
-    let old_var = env::var("OLLAMA_HOST").ok();
-    env::set_var("OLLAMA_HOST", format!("{}:{}", host, port));
+    let old_var = env::var(DriaEnv::OLLAMA_HOST_KEY).ok();
+    env::set_var(DriaEnv::OLLAMA_HOST_KEY, format!("{}:{}", host, port));
     let command = Command::new(exe_path)
         .arg("serve")
         .stdout(Stdio::null()) // ignored
@@ -46,9 +46,9 @@ pub async fn spawn_ollama(dria_env: &DriaEnv) -> Result<Child> {
 
     // restore old variable
     if let Some(val) = old_var {
-        env::set_var("OLLAMA_HOST", val);
+        env::set_var(DriaEnv::OLLAMA_HOST_KEY, val);
     } else {
-        env::remove_var("OLLAMA_HOST");
+        env::remove_var(DriaEnv::OLLAMA_HOST_KEY);
     }
 
     // check ollama to see if its running
@@ -84,6 +84,7 @@ pub async fn check_ollama(dria_env: &DriaEnv) -> bool {
     }
 }
 
+/// Pulls a model from the Ollama server with progress indication.
 pub async fn pull_model_with_progress(ollama: &Ollama, model_name: String) -> Result<()> {
     let mut pull_stream = ollama.pull_model_stream(model_name.clone(), false).await?;
     let mut pull_error: Option<OllamaError> = None;
@@ -135,8 +136,8 @@ mod tests {
     #[ignore = "requires Ollama"]
     async fn test_ollama_spawn_and_check() {
         let mut dria_env = DriaEnv::new_from_env();
-        dria_env.set("OLLAMA_HOST", "http://127.0.0.1");
-        dria_env.set("OLLAMA_PORT", "11438"); // not the default port!
+        dria_env.set(DriaEnv::OLLAMA_HOST_KEY, "http://127.0.0.1");
+        dria_env.set(DriaEnv::OLLAMA_PORT_KEY, "11438"); // not the default port!
         let mut child = spawn_ollama(&dria_env).await.unwrap();
 
         // check for healthiness

--- a/src/utils/ollama.rs
+++ b/src/utils/ollama.rs
@@ -32,8 +32,6 @@ pub async fn spawn_ollama(dria_env: &DriaEnv) -> Result<Child> {
         "could not find Ollama executable, please install it from https://ollama.com/download",
     )?;
 
-    log::debug!("Using Ollama executable at {:?}", exe_path);
-
     // ollama requires the OLLAMA_HOST environment variable to be set before launching
     let old_var = env::var(DriaEnv::OLLAMA_HOST_KEY).ok();
     env::set_var(DriaEnv::OLLAMA_HOST_KEY, format!("{}:{}", host, port));

--- a/src/utils/referrals.rs
+++ b/src/utils/referrals.rs
@@ -107,7 +107,6 @@ impl ReferralsClient {
     }
     /// Requests a challenge from the referral API, and completes it to get a referral code.
     pub async fn get_referral_code(&self, secret_key: &SecretKey, address: &str) -> Result<String> {
-        log::debug!("Getting referral code for {}", address);
         let res = self
             .client
             .post(format!("{}/get_challenge", self.base_url))
@@ -125,7 +124,6 @@ impl ReferralsClient {
         } else {
             return Err(eyre!("Failed to get challenge: {}", res.text().await?));
         };
-        log::debug!("Got challenge: {}", challenge);
 
         // alice signs the challenge and calls `get_code`
         let digest = eip191_hash(&challenge);

--- a/src/utils/signal.rs
+++ b/src/utils/signal.rs
@@ -53,7 +53,5 @@ pub async fn wait_for_termination(cancellation: CancellationToken) -> std::io::R
         cancellation.cancel();
     }
 
-    log::info!("Terminating the application...");
-
     Ok(())
 }


### PR DESCRIPTION
- [x] Added better checks for each command, also removed checks from commands that did not need it (e.g. `uninstall` works even if you dont have an `.env`)
- [x] Added profiles: you can have multiple envs managed by the same launcher, helps with running different settings in the same machine, resolves #35 
- [x] Now pulls the missing models, and asks for missing API keys when a model is changed.
- [x] Added better help messages
- [x] Overall refactors for env management
- [x] Now only well-formed versions are shown on `specific` command

Comes with v0.1.7.