### PR TITLE
Enable deletion of API keys

### DIFF
--- a/src/settings/apikey.rs
+++ b/src/settings/apikey.rs
@@ -99,7 +99,7 @@ impl DriaApiKeyKind {
         inquire::Text::new(&format!("Enter your {}:", self.name()))
             .with_default(dria_env.get(self.name()).unwrap_or_default())
             .with_help_message(&format!(
-                "{}, type 'delete' to delete the API key",
+                "{} | type 'delete' to remove the API key",
                 self.help_message()
             ))
             .prompt()

--- a/src/settings/apikey.rs
+++ b/src/settings/apikey.rs
@@ -26,6 +26,12 @@ pub fn edit_api_keys(dria_env: &mut DriaEnv) -> eyre::Result<()> {
             continue;
         };
 
+        // delete the API key
+        if new_value.eq_ignore_ascii_case("delete") {
+            dria_env.set(chosen_api_key.name(), "");
+            continue;
+        }
+
         dria_env.set(chosen_api_key.name(), new_value);
     }
 
@@ -92,7 +98,10 @@ impl DriaApiKeyKind {
     pub fn prompt_api(&self, dria_env: &DriaEnv) -> InquireResult<String> {
         inquire::Text::new(&format!("Enter your {}:", self.name()))
             .with_default(dria_env.get(self.name()).unwrap_or_default())
-            .with_help_message(self.help_message())
+            .with_help_message(&format!(
+                "{}, type 'delete' to delete the API key",
+                self.help_message()
+            ))
             .prompt()
     }
 }


### PR DESCRIPTION
This PR enables deletion of an API key if the user enters 'delete' in the API key prompt.

'delete' is case insensitive so "DELETE" &  "dELeTE" will work fine.


resolves <https://github.com/firstbatchxyz/dkn-compute-launcher/issues/49>